### PR TITLE
Modified product card and product link

### DIFF
--- a/ERP_Laravel/resources/views/layouts/app.blade.php
+++ b/ERP_Laravel/resources/views/layouts/app.blade.php
@@ -48,6 +48,11 @@
                 <i class=" fas fa-store-alt fa-2x text-success"></i>
 
                 <h1 class="ml-3">ShopERP</h1>
+                @guest
+                
+                    <a class="nav-link" style="text-decoration:none;" href="{{ route('product.publicIndex') }}"><h5>{{ __('Products') }}</h5></a>
+                
+                @endguest
             </div>
 
                 <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="{{ __('Toggle navigation') }}">
@@ -115,9 +120,7 @@
                     <ul class="ml-auto navbar-nav">
                         <!-- Authentication Links -->
                         @guest
-                        <li class="nav-item">
-                            <a class="nav-link" href="{{ route('product.publicIndex') }}">{{ __('Products') }}</a>
-                        </li>
+                        
                         @if (Route::has('login'))
                         <li class="nav-item">
                             <a class="nav-link" href="{{ route('login') }}">{{ __('Login') }}</a>

--- a/ERP_Laravel/resources/views/products/index.blade.php
+++ b/ERP_Laravel/resources/views/products/index.blade.php
@@ -25,7 +25,7 @@
                 </p>
                 <div class="mb-0 mt-auto">
                   <a class="stretched-link" href="{{ route('product.showPublic',  $product->id) }}"></a>
-                  <a type="button" class="btn btn-warning btn-lg btn-block shop-button"  href="#"><i class="fas fa-shopping-cart"></i>&nbsp;{{__("publicProducts.Add to cart")}}</a>
+                  <a type="button" style="z-index: 1; position:relative;"class="btn btn-warning btn-lg btn-block shop-button"  href="#"><i class="fas fa-shopping-cart"></i>&nbsp;{{__("publicProducts.Add to cart")}}</a>
                 </div>
               </div>
               <div class="card-footer">


### PR DESCRIPTION
Product card has now its 'Add to cart' button clickable (even without the functionality implemented). Changed z-index of the button. 
Product (public) link in app.blade.php has been repositioned in order to make its position more intuitive (it was next to the 'Login' and 'Register' links). Now its position next to the ShopERP logo.